### PR TITLE
Escape windows filter to support spaces and fix #48

### DIFF
--- a/R/backend-wincred.R
+++ b/R/backend-wincred.R
@@ -317,7 +317,9 @@ b_wincred_list <- function(self, private, service, keyring) {
     paste0(keyring, ":", service, ":*")
   }
 
-  list <- b_wincred_i_enumerate(filter)
+  list <- b_wincred_i_enumerate(
+    b_wincred_i_escape(filter)
+  )
 
   ## Filter out the credentials that belong to the keyring or its lock
   list <- grep("(::|::unlocked)$", list, value = TRUE, invert = TRUE)


### PR DESCRIPTION
Fix for https://github.com/r-lib/keyring/issues/48.