### PR TITLE
Minor format correction

### DIFF
--- a/man/backend_keyrings.Rd
+++ b/man/backend_keyrings.Rd
@@ -30,7 +30,7 @@ the default keyring, and/or a non-empty keyring with a password or
 a confirmation dialog.
 \item \code{keyring_lock()} locks a keyring.
 \item \code{keyring_unlock()} unlocks a keyring.
-\item `keyring_is_locked() checks whether a keyring is locked.
+\item \code{keyring_is_locked()} checks whether a keyring is locked.
 \item \code{keyring_default()} returns the default keyring.
 \item \code{keyring_set_default()} sets the default keyring.
 }


### PR DESCRIPTION
The extra backtick was added in 2018 (commit 6655632), but it seems that the documentation hasn't been regenerated since the update was made? This carries that change through to the documentation.

Might be best just to regenerate the documentation, but in case there's a good reason not to, this should fix the issue.