### PR TITLE
Fixes keyring create name inversion issue

### DIFF
--- a/R/backend-macos.R
+++ b/R/backend-macos.R
@@ -15,7 +15,7 @@
 #' \dontrun{
 #' ## This only works on macOS
 #' kb <- backend_macos$new()
-#' kb$create_keyring("foobar")
+#' kb$keyring_create("foobar")
 #' kb$set_default_keyring("foobar")
 #' kb$set_with_value("service", password = "secret")
 #' kb$get("service")

--- a/R/backend-secret-service.R
+++ b/R/backend-secret-service.R
@@ -26,7 +26,7 @@
 #' \dontrun{
 #' ## This only works on Linux, typically desktop Linux
 #' kb <- backend_secret_service$new()
-#' kb$create_keyring("foobar")
+#' kb$keyring_create("foobar")
 #' kb$set_default_keyring("foobar")
 #' kb$set_with_value("service", password = "secret")
 #' kb$get("service")
@@ -206,6 +206,6 @@ b_ss_keyring_create_direct <- function(self, private, keyring, password) {
     warning("Password ignored, will be read interactively")
   }
   keyring <- keyring %||% private$keyring
-  .Call("keyring_secret_service_create_keyring", keyring)
+  .Call("keyring_secret_service_keyring_create", keyring)
   invisible(self)
 }

--- a/R/backend-wincred.R
+++ b/R/backend-wincred.R
@@ -149,7 +149,7 @@ b_wincred_is_locked_keyring_internal <- function(keyring) {
 #' \dontrun{
 #' ## This only works on Windows
 #' kb <- backend_wincred$new()
-#' kb$create_keyring("foobar")
+#' kb$keyring_create("foobar")
 #' kb$set_default_keyring("foobar")
 #' kb$set_with_value("service", password = "secret")
 #' kb$get("service")

--- a/man/backend_macos.Rd
+++ b/man/backend_macos.Rd
@@ -21,7 +21,7 @@ See \link{backend} for the documentation of the individual methods.
 \dontrun{
 ## This only works on macOS
 kb <- backend_macos$new()
-kb$create_keyring("foobar")
+kb$keyring_create("foobar")
 kb$set_default_keyring("foobar")
 kb$set_with_value("service", password = "secret")
 kb$get("service")

--- a/man/backend_secret_service.Rd
+++ b/man/backend_secret_service.Rd
@@ -32,7 +32,7 @@ not available.
 \dontrun{
 ## This only works on Linux, typically desktop Linux
 kb <- backend_secret_service$new()
-kb$create_keyring("foobar")
+kb$keyring_create("foobar")
 kb$set_default_keyring("foobar")
 kb$set_with_value("service", password = "secret")
 kb$get("service")

--- a/man/backend_wincred.Rd
+++ b/man/backend_wincred.Rd
@@ -23,7 +23,7 @@ See \link{backend} for the documentation of the individual methods.
 \dontrun{
 ## This only works on Windows
 kb <- backend_wincred$new()
-kb$create_keyring("foobar")
+kb$keyring_create("foobar")
 kb$set_default_keyring("foobar")
 kb$set_with_value("service", password = "secret")
 kb$get("service")

--- a/src/keyring_secret_service.c
+++ b/src/keyring_secret_service.c
@@ -99,7 +99,7 @@ GList* keyring_secret_service_list_collections() {
     &err);
 
   if (err || !secretservice) {
-    keyring_secret_service_handle_status("create_keyring", TRUE, err);
+    keyring_secret_service_handle_status("keyring_create", TRUE, err);
     error("Cannot connect to secret service");
   }
 
@@ -109,7 +109,7 @@ GList* keyring_secret_service_list_collections() {
     &err);
 
   if (status || err) {
-    keyring_secret_service_handle_status("create_keyring", status, err);
+    keyring_secret_service_handle_status("keyring_create", status, err);
   }
 
   GList *collections = secret_service_get_collections(secretservice);
@@ -355,7 +355,7 @@ SEXP keyring_secret_service_list(SEXP keyring, SEXP service) {
   return result;
 }
 
-SEXP keyring_secret_service_create_keyring(SEXP keyring) {
+SEXP keyring_secret_service_keyring_create(SEXP keyring) {
 
   const char *ckeyring = CHAR(STRING_ELT(keyring, 0));
 
@@ -367,7 +367,7 @@ SEXP keyring_secret_service_create_keyring(SEXP keyring) {
     &err);
 
   if (err || !secretservice) {
-    keyring_secret_service_handle_status("create_keyring", TRUE, err);
+    keyring_secret_service_handle_status("keyring_create", TRUE, err);
     error("Cannot connect to secret service");
   }
 
@@ -380,7 +380,7 @@ SEXP keyring_secret_service_create_keyring(SEXP keyring) {
     &err);
 
   g_object_unref(secretservice);
-  keyring_secret_service_handle_status("create_keyring", TRUE, err);
+  keyring_secret_service_handle_status("keyring_create", TRUE, err);
 
   if (collection) g_object_unref(collection);
 
@@ -512,8 +512,8 @@ static const R_CallMethodDef callMethods[]  = {
     (DL_FUNC) &keyring_secret_service_delete, 3 },
   { "keyring_secret_service_list",
     (DL_FUNC) &keyring_secret_service_list, 2 },
-  { "keyring_secret_service_create_keyring",
-    (DL_FUNC) &keyring_secret_service_create_keyring, 1 },
+  { "keyring_secret_service_keyring_create",
+    (DL_FUNC) &keyring_secret_service_keyring_create, 1 },
   { "keyring_secret_service_list_keyring",
     (DL_FUNC) &keyring_secret_service_list_keyring, 0 },
   { "keyring_secret_service_delete_keyring",


### PR DESCRIPTION
The example given in the manual of backend_secret_service was triggering an error with message "Error: attempt to apply non-function" due to calling kb$create_keyring instead of calling kb$keyring_create. Fixing the example by calling the latter does not solve the issue. Hence, I replace create_keyring with keyring_create in the manual, on R side, and on C side. Now it works without errors.