### PR TITLE
fix: dont use hardcoded bash interpreter path

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -1,3 +1,3 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 rm -f src/Makevars

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "PKG_LIBS=-framework Security" > src/Makevars


### PR DESCRIPTION
Currently the scripts assume  `bash` is present on a static path. That's not the case on all distros (e.g. NixOS -> `/run/current-system/sw/bin/bash`). 

The PR allows for a more predictable behavior for majority of distros. 