### PR TITLE
test: replace mockery with testthat mocking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,6 @@ Imports:
 Suggests:
     callr,
     covr,
-    mockery,
     testthat (>= 3.0.0),
     withr
 Config/Needs/website: tidyverse/tidytemplate

--- a/R/utils.R
+++ b/R/utils.R
@@ -80,3 +80,6 @@ is_interactive <- function() {
     interactive()
   }
 }
+
+# https://testthat.r-lib.org/reference/local_mocked_bindings.html#base-functions
+Sys.info <- NULL

--- a/tests/testthat/test-default-backend.R
+++ b/tests/testthat/test-default-backend.R
@@ -50,22 +50,22 @@ test_that("mixing options and env vars", {
 })
 
 test_that("auto windows", {
-  mockery::stub(default_backend_auto, "Sys.info", c(sysname = "Windows"))
+  local_mocked_bindings(Sys.info = function(...) c(sysname = "Windows"))
   expect_equal(default_backend_auto(), backend_wincred)
 })
 
 test_that("auto macos", {
-  mockery::stub(default_backend_auto, "Sys.info", c(sysname = "Darwin"))
+  local_mocked_bindings(Sys.info = function(...) c(sysname = "Darwin"))
   expect_equal(default_backend_auto(), backend_macos)
 })
 
 test_that("auto linux", {
-  skip_if_not_linux()  
+  skip_if_not_linux()
   kb <- default_backend()
   expect_true(kb$name == "env" || kb$name == "secret service" || kb$name == "file")
 })
 
 test_that("auto other", {
-  mockery::stub(default_backend_auto, "Sys.info", c(sysname = "Solaris"))
+  local_mocked_bindings(Sys.info = function(...) c(sysname = "Solaris"))
   expect_equal(suppressWarnings(default_backend_auto()), backend_file)
 })


### PR DESCRIPTION
I'm suggesting this because I'd like to write an update to my post from 2019, where the real example was this keyring test. :innocent: https://blog.r-hub.io/2019/10/29/mocking/#general-mocking