### PR TITLE
Fixed windows casing bug on setting credentials

### DIFF
--- a/R/backend-wincred.R
+++ b/R/backend-wincred.R
@@ -356,6 +356,14 @@ b_wincred_set_with_raw_value <- function(self, private, service,
 
   keyring <- keyring %||% private$keyring
   target <- b_wincred_target(keyring, service, username)
+
+  # Check for mis-cased target
+  stored <- b_wincred_i_enumerate("*")
+  if ((!target %in% stored) && (tolower(target) %in% tolower(stored))) {
+    # Automatically update case
+    target <- stored[tolower(stored) == tolower(target)]
+  }
+
   if (is.null(keyring)) {
     b_wincred_i_set(target, password, username = username)
     return(invisible(self))


### PR DESCRIPTION
Addresses issue #155 by making key_set() case-insensitive on Windows (matching the behavior of key_get()).