### PR TITLE
Add a note about using `oskeyring` to access keys created by other software.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,6 @@ Config/testthat/edition: 3
 Config/usethis/last-upkeep: 2025-04-30
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = FALSE)
-RoxygenNote: 7.3.2.9000
+RoxygenNote: 7.3.3
 SystemRequirements: Optional: libsecret on Linux (libsecret-1-dev on
     Debian/Ubuntu, libsecret-devel on Fedora/CentOS)

--- a/R/api.R
+++ b/R/api.R
@@ -24,7 +24,9 @@
 #' `key_delete` deletes a key.
 #'
 #' `key_list` lists all keys of a keyring, or the keys for a certain
-#' service (if `service` is not `NULL`).
+#' service (if `service` is not `NULL`). Note that `key_list` cannot
+#' access keys that are created by another software. To access such
+#' keys see the `{oskeyring}` package instead.
 #'
 #' `key_list_raw()` is like `key_list()` but also returns the keys as raw
 #' values. This is useful if your keys have bytes that cannot appear

--- a/man/key_get.Rd
+++ b/man/key_get.Rd
@@ -90,7 +90,9 @@ vector.
 \code{key_delete} deletes a key.
 
 \code{key_list} lists all keys of a keyring, or the keys for a certain
-service (if \code{service} is not \code{NULL}).
+service (if \code{service} is not \code{NULL}). Note that \code{key_list} cannot
+access keys that are created by another software. To access such
+keys see the \code{{oskeyring}} package instead.
 
 \code{key_list_raw()} is like \code{key_list()} but also returns the keys as raw
 values. This is useful if your keys have bytes that cannot appear


### PR DESCRIPTION
Fixes #121